### PR TITLE
Use original materials and random train selection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,7 @@ const spawn = rails.getSpawnPose();
 const train = createTrain({
   random: true,
   pose: { position: spawn.position, yaw: spawn.yaw, railY: rails.railHeight },
+  carLength: rails.chordLen * 0.8,
 });
 scene.add(train);
 

--- a/src/scene/cliffs.ts
+++ b/src/scene/cliffs.ts
@@ -1,9 +1,7 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { COLORS } from './uiColors';
 
 const loader = new GLTFLoader();
-const srgb = (hex: number | string) => new THREE.Color(hex as any).convertSRGBToLinear();
 
 export function createCliffs() {
   const group = new THREE.Group();
@@ -20,12 +18,13 @@ export function createCliffs() {
       const level = base.clone(true);
       level.traverse((o: any) => {
         if (o.isMesh) {
-          const m = (o.material as THREE.MeshStandardMaterial).clone();
-          if (m.map) m.map.colorSpace = THREE.SRGBColorSpace;
-          m.color = srgb(COLORS.terrain);
-          m.metalness = 0;
-          m.roughness = 0.9;
-          o.material = m;
+          const mats = Array.isArray(o.material) ? o.material : [o.material];
+          mats.forEach((m: any) => {
+            if (m.map) {
+              m.map.colorSpace = THREE.SRGBColorSpace;
+              m.map.anisotropy = 4;
+            }
+          });
           o.castShadow = true;
           o.receiveShadow = true;
         }
@@ -46,7 +45,10 @@ function ensureSRGB(obj: THREE.Object3D) {
       const mats = Array.isArray(o.material) ? o.material : [o.material];
       mats.forEach((m) => {
         const mat = m as THREE.MeshStandardMaterial;
-        if (mat.map) mat.map.colorSpace = THREE.SRGBColorSpace;
+        if (mat.map) {
+          mat.map.colorSpace = THREE.SRGBColorSpace;
+          mat.map.anisotropy = 4;
+        }
       });
     }
   });

--- a/src/scene/ground.ts
+++ b/src/scene/ground.ts
@@ -1,58 +1,48 @@
 import * as THREE from 'three';
-import { COLORS } from './uiColors';
-
-const srgb = (hex: number | string) => new THREE.Color(hex as any).convertSRGBToLinear();
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
 export function createGround() {
   const width = 32;
   const depth = 24;
-  const baseHeight = 1;
   const group = new THREE.Group();
+  const loader = new GLTFLoader();
 
-  const baseGeo = new THREE.BoxGeometry(width + 2, baseHeight, depth + 2);
-  const baseMat = new THREE.MeshStandardMaterial({
-    color: srgb(COLORS.terrain), metalness: 0, roughness: 0.85,
+  loader.load('/assets/nature/platform_grass.glb', (gltf) => {
+    const mesh = gltf.scene;
+    ensureSRGB(mesh);
+    mesh.traverse((o: any) => {
+      if (o.isMesh) { o.receiveShadow = true; }
+    });
+
+    // Escala al área deseada
+    mesh.updateWorldMatrix(true, true);
+    const box = new THREE.Box3().setFromObject(mesh);
+    const size = box.getSize(new THREE.Vector3());
+    const sx = width / (size.x || 1);
+    const sz = depth / (size.z || 1);
+    mesh.scale.set(sx, 1, sz);
+    mesh.updateWorldMatrix(true, true);
+    // centra
+    const box2 = new THREE.Box3().setFromObject(mesh);
+    const center = box2.getCenter(new THREE.Vector3());
+    mesh.position.sub(center);
+
+    group.add(mesh);
   });
-  const base = new THREE.Mesh(baseGeo, baseMat);
-  base.position.y = -baseHeight / 2;
-  base.receiveShadow = true;
-  group.add(base);
-
-  const geo = new THREE.PlaneGeometry(width, depth, 32, 24);
-  const pos = geo.attributes.position as THREE.BufferAttribute;
-  for (let i = 0; i < pos.count; i++) {
-    const y = (Math.random() - 0.5) * 0.05;
-    pos.setY(i, y);
-  }
-  geo.computeVertexNormals();
-  geo.rotateX(-Math.PI / 2);
-// scene/ground.ts (dentro de createGround, tras crear el geo y antes del material)
-function tinyGrassTexture() {
-  const c = document.createElement('canvas');
-  c.width = c.height = 4;
-  const ctx = c.getContext('2d')!;
-  // parches suaves
-  const g1 = '#e8fab5', g2 = '#dff6a1', g3 = '#e4f9b0';
-  ctx.fillStyle = g1; ctx.fillRect(0,0,4,4);
-  ctx.fillStyle = g2; ctx.fillRect(0,0,2,2);
-  ctx.fillStyle = g3; ctx.fillRect(2,2,2,2);
-  const tex = new THREE.CanvasTexture(c);
-  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-  tex.repeat.set(16, 12); // tablero 32×24 -> 2 texels por unidad
-  tex.colorSpace = THREE.SRGBColorSpace;
-  return tex;
-}
-
-const mat = new THREE.MeshStandardMaterial({
-  color: srgb(0xDFF6A1),
-  metalness: 0,
-  roughness: 0.85,
-  map: tinyGrassTexture(),   // << añade variación sutil
-});
-
-  const mesh = new THREE.Mesh(geo, mat);
-  mesh.receiveShadow = true;
-  group.add(mesh);
 
   return group;
+}
+
+function ensureSRGB(obj: THREE.Object3D) {
+  obj.traverse((o) => {
+    if (o instanceof THREE.Mesh) {
+      const mats = Array.isArray(o.material) ? o.material : [o.material];
+      mats.forEach((m: any) => {
+        if (m.map) {
+          m.map.colorSpace = THREE.SRGBColorSpace;
+          m.map.anisotropy = 4;
+        }
+      });
+    }
+  });
 }

--- a/src/scene/rails.ts
+++ b/src/scene/rails.ts
@@ -32,16 +32,12 @@ export function createRails() {
   function preparePiece(obj: THREE.Object3D) {
     obj.traverse((o: any) => {
       if (!o.isMesh) return;
-      const name = (o.name || '').toLowerCase();
-      const color =
-        name.includes('rail')  ? 0x6F6F6F :      // metal
-        name.includes('sleep') ? 0x8B5A2B :      // durmientes
-                                0x8B5A2B;
-      o.material = new THREE.MeshStandardMaterial({
-        color: new THREE.Color(color).convertSRGBToLinear(),
-        metalness: 0,
-        roughness: 0.6,
-        flatShading: true,
+      const mats = Array.isArray(o.material) ? o.material : [o.material];
+      mats.forEach((m: any) => {
+        if (m.map) {
+          m.map.colorSpace = THREE.SRGBColorSpace;
+          m.map.anisotropy = 4;
+        }
       });
       o.castShadow = true; o.receiveShadow = true;
     });
@@ -82,7 +78,7 @@ export function createRails() {
   async function loadFirstExisting(paths: string[]) {
     for (const p of paths) {
       try {
-        const gltf = await new Promise<THREE.Object3D | null>((resolve, reject) => {
+        const gltf = await new Promise<THREE.Object3D | null>((resolve) => {
           loader.load(p, (g) => resolve(g.scene), undefined, () => resolve(null));
         });
         if (gltf) return gltf;
@@ -95,5 +91,6 @@ export function createRails() {
     group,
     getSpawnPose: () => poseAt(0),
     railHeight: Y_RAIL,
+    chordLen: chord,
   };
 }


### PR DESCRIPTION
## Summary
- Load ground and props from GLTF assets preserving their native materials and textures
- Build rail loop from unmodified straight segments and export chord length for train sizing
- Choose random trains from Kenney GLBs or Quaternius OBJ/MTL sets and scale cars to rail chord

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ba45a33d0832b98ad2b52f6abac5d